### PR TITLE
chore: Updating Python Requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -95,7 +95,7 @@ distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.16
+django==3.2.17
     # via
     #   -r requirements/test.txt
     #   openedx-django-pyfs


### PR DESCRIPTION
Updates `django` from `3.2.16` to `3.2.17`