### PR TITLE
fix: StudioContainerXBlockMixin needs to be updated to match edx-platform changes [BD-13]

### DIFF
--- a/tests/integration/test_studio_editable.py
+++ b/tests/integration/test_studio_editable.py
@@ -2,6 +2,9 @@ import datetime
 import textwrap
 from unittest import mock
 import pytz
+
+from django.conf import settings
+from django.test import modify_settings
 from selenium.common.exceptions import NoSuchElementException
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Float, Integer, List, String, DateTime
@@ -429,15 +432,11 @@ class XBlockWithOverriddenNested(StudioContainerWithNestedXBlocksMixin, XBlock):
         ]
 
 
+@modify_settings
 class StudioContainerWithNestedXBlocksTest(StudioContainerWithNestedXBlocksBaseTest):
     def setUp(self):
         super().setUp()
-        patcher = mock.patch(
-            'workbench.runtime.WorkbenchRuntime.render_template', mock.Mock(side_effect=render_template)
-        )
-        patcher.start()
-
-        self.addCleanup(patcher.stop)
+        settings.WORKBENCH.services["mako"] = mock.Mock(render_template=mock.Mock(side_effect=render_template))
 
     def _check_button(self, button, category, label, single, disabled, disabled_reason='', boilerplate=None):
         self.assertEqual(button.get_attribute('data-category'), category)

--- a/xblockutils/__init__.py
+++ b/xblockutils/__init__.py
@@ -2,4 +2,4 @@
 Useful classes and functionality for building and testing XBlocks
 """
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -13,7 +13,7 @@ StudioEditableXBlockMixin to your XBlock.
 import logging
 import simplejson as json
 
-from xblock.core import XBlock
+from xblock.core import XBlock, XBlockMixin
 from xblock.fields import Scope, JSONField, List, Integer, Float, Boolean, String, DateTime
 from xblock.exceptions import JsonHandlerError, NoSuchViewError
 from web_fragments.fragment import Fragment
@@ -269,7 +269,8 @@ class StudioEditableXBlockMixin:
         return validation
 
 
-class StudioContainerXBlockMixin:
+@XBlock.needs('mako')
+class StudioContainerXBlockMixin(XBlockMixin):
     """
     An XBlock mixin to provide convenient use of an XBlock in Studio
     that wants to allow the user to assign children to it.
@@ -300,7 +301,10 @@ class StudioContainerXBlockMixin:
                 'content': rendered_child.content
             })
 
-        fragment.add_content(self.runtime.render_template("studio_render_children_view.html", {
+        mako_service = self.runtime.service(self, 'mako')
+        # 'lms.' namespace_prefix is required for rendering in studio
+        mako_service.namespace_prefix = 'lms.'
+        fragment.add_content(mako_service.render_template("studio_render_children_view.html", {
             'items': contents,
             'xblock_context': context,
             'can_add': can_add,


### PR DESCRIPTION
The Problem Builder XBlock has not been working in master versions of edx-platform, after https://github.com/openedx/edx-platform/commit/248c090eee82acbfb84c21c0b47f1c02d9b5a258 was merged via https://github.com/openedx/edx-platform/pull/31472 .

Without this fix:

![Screenshot 2023-05-18 at 4 43 19 PM](https://github.com/openedx/xblock-utils/assets/945577/aee44798-3eaa-4727-b9d6-745804ee7095)

With this fix:
![Screenshot 2023-05-18 at 4 45 21 PM](https://github.com/openedx/xblock-utils/assets/945577/8c0c2f4a-4f3f-482e-8bc4-ae97453b4e09)


This bug was reported at https://discuss.openedx.org/t/reporting-supporting-a-fix-for-problem-builder-x-block-issue/10114/2

Private ref: MNG-3708