### PR TITLE
fix!: use TinyMCE 5 as HTML editor

### DIFF
--- a/xblockutils/__init__.py
+++ b/xblockutils/__init__.py
@@ -2,4 +2,4 @@
 Useful classes and functionality for building and testing XBlocks
 """
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'

--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -51,17 +51,18 @@ function StudioEditableXBlockMixin(runtime, element) {
         if (type == 'html' && tinyMceAvailable) {
             tinyMCE.baseURL = baseUrl + "/js/vendor/tinymce/js/tinymce";
             $field.tinymce({
-                theme: 'modern',
-                skin: 'studio-tmce4',
+                theme: 'silver',
+                skin: 'studio-tmce5',
+                content_css: 'studio-tmce5',
                 height: '200px',
                 formats: { code: { inline: 'code' } },
                 codemirror: { path: "" + baseUrl + "/js/vendor" },
                 convert_urls: false,
-                plugins: "link codemirror",
+                plugins: "lists, link, codemirror",
                 menubar: false,
                 statusbar: false,
                 toolbar_items_size: 'small',
-                toolbar: "formatselect | styleselect | bold italic underline forecolor wrapAsCode | bullist numlist outdent indent blockquote | link unlink | code",
+                toolbar: "formatselect | styleselect | bold italic underline forecolor | bullist numlist outdent indent blockquote | link unlink | code",
                 resize: "both",
                 extended_valid_elements : 'i[class],span[class]',
                 setup : function(ed) {


### PR DESCRIPTION
## Description

We removed TinyMCE 4 from the platform last year. The editor changes are similar to https://github.com/openedx/edx-ora2/pull/1869.

## Testing instructions
1. Install [edx-sga](https://github.com/mitodl/edx-sga/).
2. Check that the "Solution" field in Studio has a working TinyMCE editor.

## Author's notes

BREAKING CHANGE: This is incompatible with Nutmeg.