### PR TITLE
build: Update upgrade-python-requirements.yml

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,13 +8,13 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: '$default-branch'
+        default: 'master'
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || '$default-branch' }}
+      branch: ${{ github.event.inputs.branch || github.event.repository.default_branch }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""


### PR DESCRIPTION
The $default_branch workflow-template was supposed to get rendered when the workflow was copied but it didn't get updated.  It looks like you can get to the default branch this way as well so seeing if that will work as a more general solution that we can backport to the workflow-template.