### PR TITLE
build: Update how we read requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def load_requirements(*requirements_paths):
     constraint_files = set()
 
     # groups "my-package-name<=x.y.z,..." into ("my-package-name", "<=x.y.z,...")
-    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.]+)([<>=][^#\s]+)?")
+    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?")
 
     def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
         regex_match = requirement_line_regex.match(current_line)

--- a/xblockutils/__init__.py
+++ b/xblockutils/__init__.py
@@ -2,4 +2,4 @@
 Useful classes and functionality for building and testing XBlocks
 """
 
-__version__ = '3.4.0'
+__version__ = '3.4.1'


### PR DESCRIPTION
See https://github.com/openedx/edx-cookiecutters/pull/377/files for more
details but essentially, we weren't previously advertising our extra
dependencies correctly, so start doing that here.
